### PR TITLE
Allow minimum word length to be configured

### DIFF
--- a/src/word-joiner.coffee
+++ b/src/word-joiner.coffee
@@ -1,3 +1,16 @@
+# Description:
+#   A hubot script that seizes opportunities to join words into newer,
+#   hopefully better words.
+#
+# Configuration:
+#   HUBOT_WORD_JOINER_MINIMUM: optional
+#
+# Notes:
+#   The minimum word length threshold cannot be set to less than two.
+#
+# Author:
+#   Jake Swanson
+
 overlap = 2
 minimum = Math.max(overlap, parseInt(process.env.HUBOT_WORD_JOINER_MINIMUM ? 3, 10)) - overlap
 pattern = new RegExp '\\w{' + minimum + ',}(\\w{' + overlap + ',})(\\W+)\\1\\w{' + minimum + ',}'

--- a/src/word-joiner.coffee
+++ b/src/word-joiner.coffee
@@ -1,4 +1,8 @@
+overlap = 2
+minimum = Math.max(overlap, parseInt(process.env.HUBOT_WORD_JOINER_MINIMUM ? 3, 10)) - overlap
+pattern = new RegExp '\\w{' + minimum + ',}(\\w{' + overlap + ',})(\\W+)\\1\\w{' + minimum + ',}'
+
 module.exports = (robot) ->
-  robot.hear /\w+(\w{2,})(\W+)\1\w+/, (msg) ->
+  robot.hear pattern, (msg) ->
     new_word = msg.match[0].replace(msg.match[1] + msg.match[2], '')
     msg.send "#{new_word}, you mean?"


### PR DESCRIPTION
We were getting "with the" becoming "withe" a LOT.

To counter this I've added the `HUBOT_WORD_JOINER_MINIMUM` env var which defines the minimum word length both words must be before joining them. The default (when unset) is `3` the same as it's always been, and cannot be set to less than `2`, the length of the overlap itself. Here are some examples:

Default (no config; default 3):

```
Pattern: /\w{1,}(\w{2,})(\W+)\1\w{1,}/

jeff> in into
jeff> with the
withe, you mean?
jeff> alibaba badass
alibabadass, you mean?
```

Longer:

```
HUBOT_WORD_JOINER_MINIMUM=4
Pattern: /\w{2,}(\w{2,})(\W+)\1\w{2,}/

jeff> in into
jeff> with the
jeff> alibaba badass
alibabadass, you mean?
```

Shorter:

```
HUBOT_WORD_JOINER_MINIMUM=2
Pattern: /\w{0,}(\w{2,})(\W+)\1\w{0,}/

jeff> in into
into, you mean?
jeff> with the
withe, you mean?
jeff> alibaba badass
alibabadass, you mean?
```
